### PR TITLE
Support Laravel 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.1",
     "prismic/php-sdk": "5.1.1",
-    "illuminate/support": "^5.5|^6.0|^7.0"
+    "illuminate/support": "^5.5|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~7.0",


### PR DESCRIPTION
Laravel 8.0 will be released today.
Explicitly allow ^8.0